### PR TITLE
Add issue ingestion templates and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Something is broken or behaving unexpectedly
+labels: ["needs-triage", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Fill in as much as you can — the more detail, the faster it moves to resolution.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the bug
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps that reliably trigger the bug
+      placeholder: "1. Go to...\n2. Click...\n3. See error"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / environment
+      description: App version, OS, browser, or other relevant context

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Propose a new feature or improvement
+labels: ["needs-triage", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you're trying to solve, not just the solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What are you trying to accomplish? What's the current limitation?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you consider? Why didn't it fit?
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How would you verify this feature is working?
+      placeholder: "- [ ] When I do X, Y happens\n- [ ] The UI shows Z"

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+Label names used by the `/issue-intake` pipeline in this repo.
+
+| canonical name | label in this repo | notes |
+|---|---|---|
+| `needs-triage` | `needs-triage` | Applied automatically on issue submission via templates |
+| `needs-info` | `needs-info` | Applied when issue is missing repro steps or problem context |
+| `ready-for-agent` | `ready-for-agent` | Issue is fully specified; Agent Brief has been drafted |
+| `approved-for-agent` | `approved-for-agent` | Human has approved the issue for autonomous execution |
+| `wontfix` | `wontfix` | Issue is out of scope; will not be actioned |
+| `bug` | `bug` | Something is broken or behaving unexpectedly |
+| `enhancement` | `enhancement` | New feature or improvement |


### PR DESCRIPTION
## Summary
- Adds bug-report.yml and feature-request.yml GitHub issue templates that auto-apply needs-triage label on submission
- Creates 4 new labels on GitHub: needs-triage, needs-info, ready-for-agent, approved-for-agent
- Existing design-rfc.yml template is untouched

This is the repo-side setup for the /issue-intake automated triage pipeline. Once merged, a scheduled routine will poll for needs-triage issues and run the triage state machine.

## Test plan
- Open a new issue on GitHub and confirm Bug Report and Feature Request templates appear alongside Design RFC
- File a test bug via the template and confirm it arrives with needs-triage and bug labels applied automatically

Generated with Claude Code