### PR TITLE
Bump actions to v6 (Node 24)

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,9 +18,9 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
@
## Summary
- `actions/checkout@v4` → `@v6`
- `actions/setup-python@v5` → `@v6`

Both now run on Node.js 24. Required before June 16 when Node 20 becomes forced off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@